### PR TITLE
Enforce the PSR-12 order of use statements

### DIFF
--- a/src/LEVIY/ruleset.xml
+++ b/src/LEVIY/ruleset.xml
@@ -56,7 +56,11 @@
             <property name="searchAnnotations" value="true"/>
         </properties>
     </rule>
-    <rule ref="SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses"/>
+    <rule ref="SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses">
+        <properties>
+            <property name="psr12Compatible" value="true"/>
+        </properties>
+    </rule>
 
     <!-- Use PHP native type hints whenever possible. Use docblocks only when
     the use of native type hints is impossible. -->


### PR DESCRIPTION
[PSR-12 states](https://github.com/php-fig/fig-standards/blob/master/proposed/extended-coding-style-guide.md#3-declare-statements-namespace-and-import-statements) that the order should be: classes, functions, constants. PhpStorm (as of version 2018.1) also uses this order when you reformat your code, so it is annoying when our coding standard enforces something different.