### PR TITLE
Add installed paths configuration for used coding standards that were…

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -3,4 +3,6 @@
     <arg name="basepath" value="."/>
 
     <rule ref="LEVIY"/>
+
+    <config name="installed_paths" value="src/LEVIY"/>
 </ruleset>

--- a/src/LEVIY/ruleset.xml
+++ b/src/LEVIY/ruleset.xml
@@ -186,4 +186,6 @@
     <rule ref="Symfony.Commenting.FunctionComment.MissingReturn">
         <severity>0</severity>
     </rule>
+
+    <config name="installed_paths" value="vendor/slevomat/coding-standard/SlevomatCodingStandard,vendor/escapestudios/symfony2-coding-standard/Symfony" />
 </ruleset>


### PR DESCRIPTION
… installed through composer.

Since the symfony and slevomat coding standards are not installed with PHPCS by default, this fix will make sure that these standards can be found by PHPCS by setting the installed path configuration targetting their respective directories inside the vendor directory.