### PR TITLE
Allow all usefull annotations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
         "escapestudios/symfony2-coding-standard": "^3.0",
         "phpmd/phpmd": "^2.6",
-        "slevomat/coding-standard": "^4.5",
+        "slevomat/coding-standard": "^4.6",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "826bfb25e09be97193003354c77f5f68",
+    "content-hash": "d2c8c8dc65f4cf93bcb88436d1afd384",
     "packages": [
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",

--- a/src/LEVIY/ruleset.xml
+++ b/src/LEVIY/ruleset.xml
@@ -66,7 +66,7 @@
     the use of native type hints is impossible. -->
     <rule ref="SlevomatCodingStandard.TypeHints.TypeHintDeclaration">
         <properties>
-            <property name="usefulAnnotations" type="array" value="@dataProvider,@Given,@When,@Then"/>
+            <property name="allAnnotationsAreUseful" value="true"/>
         </properties>
     </rule>
 

--- a/tests/correct/annotations.php
+++ b/tests/correct/annotations.php
@@ -2,8 +2,8 @@
 declare(strict_types=1);
 
 /**
- * @dataProvider
+ * @whatever
  */
-function dataProviderAnnotationsAreAllowed(): void
+function allUsefulAnnotationsAreAllowed(): void
 {
 }


### PR DESCRIPTION
Version 4.6 of Slevomat Coding Standard allows to automatically mark all annotations (except for `@param` and `@return`) as useful. This removes the need for whitelisting all useful annotations we want to use (such as `@Given`, `@When`, `@Then` for Behat, `@dataProvider` for PHPUnit, etc.).