### PR TITLE
Fix composer 2 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,7 @@ branches:
 language: php
 
 php:
-  - '7.1'
   - '7.2'
-
-matrix:
-  include:
-    - name: Test with the lowest allowed versions of dependencies
-      php: '7.1'
-      install: composer update --prefer-lowest
 
 cache:
   directories:

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
         }
     ],
     "require": {
-        "php": "^7.1",
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2",
+        "php": "^7.2",
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
         "escapestudios/symfony2-coding-standard": "^3.6",
         "phpmd/phpmd": "^2.6",
         "slevomat/coding-standard": "^6.0",


### PR DESCRIPTION
Upgrade dealerdirect/phpcodesniffer-composer-installer to 0.7.0 which adds
support for Composer 2