### PR TITLE
Upgrade slevomat/coding-standard package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
         "escapestudios/symfony2-coding-standard": "^3.6",
         "phpmd/phpmd": "^2.6",
-        "slevomat/coding-standard": "^6.0",
+        "slevomat/coding-standard": "^7.0.1",
         "squizlabs/php_codesniffer": "^3.4"
     },
     "autoload": {

--- a/src/LEVIY/ruleset.xml
+++ b/src/LEVIY/ruleset.xml
@@ -33,7 +33,8 @@
     declare(strict_types=1) (with an optional semi-colon terminator). -->
     <rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes">
         <properties>
-            <property name="newlinesCountBetweenOpenTagAndDeclare" value="1"/>
+            <property name="linesCountBeforeDeclare" value="0"/>
+            <property name="linesCountAfterDeclare" value="1"/>
             <property name="spacesCountAroundEqualsSign" value="0"/>
         </properties>
     </rule>

--- a/tests/expected.log
+++ b/tests/expected.log
@@ -18,14 +18,14 @@ PHPCBF CAN FIX THE 1 MARKED SNIFF VIOLATIONS AUTOMATICALLY
 
 
 FILE: tests/incorrect/strict-types.php
-------------------------------------------------------------------------------------------
+----------------------------------------------------------------------
 FOUND 2 ERRORS AFFECTING 1 LINE
-------------------------------------------------------------------------------------------
- 1 | ERROR | [x] Expected 1 newlines between PHP open tag and declare statement, found 0.
+----------------------------------------------------------------------
+ 1 | ERROR | [x] Expected 0 lines before declare statement, found 0.
  1 | ERROR | [x] Expected strict_types=1, found strict_types = 1.
-------------------------------------------------------------------------------------------
+----------------------------------------------------------------------
 PHPCBF CAN FIX THE 2 MARKED SNIFF VIOLATIONS AUTOMATICALLY
-------------------------------------------------------------------------------------------
+----------------------------------------------------------------------
 
 
 FILE: tests/incorrect/type-hints.php


### PR DESCRIPTION
Update was done mainly for preventing use of deprecated package: `jakub-onderka/php-parallel-lint`