### PR TITLE
LPD-15905 Upgrade deprecated actions to Node 20

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,13 +3,13 @@ on: push
 
 jobs:
   test-php7_2:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         prefer: ["prefer-stable", "prefer-lowest"]
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -17,44 +17,26 @@ jobs:
           php-version: '7.2'
           tools: composer:v2
 
-      - name: Get Composer Cache Directory
-        id: composer-cache
-        run: |
-          echo "::set-output name=dir::$(composer config cache-files-dir)"
-      - uses: actions/cache@v3
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}-${{ matrix.prefer }}-
-          restore-keys: ${{ runner.os }}-composer-${{ matrix.prefer }}-
       - name: Composer Install
         run: composer update --${{ matrix.prefer }} --no-interaction --no-progress --no-ansi
 
       - name: Run tests
         run: make check
   test-php8:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         prefer: [ "prefer-stable", "prefer-lowest" ]
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.3'
           tools: composer:v2
 
-      - name: Get Composer Cache Directory
-        id: composer-cache
-        run: |
-          echo "::set-output name=dir::$(composer config cache-files-dir)"
-      - uses: actions/cache@v3
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}-${{ matrix.prefer }}-
-          restore-keys: ${{ runner.os }}-composer-${{ matrix.prefer }}-
       - name: Composer Install
         run: composer update --${{ matrix.prefer }} --no-interaction --no-progress --no-ansi
 


### PR DESCRIPTION
Actions using Node 16 are deprecated and should be updated to Node 20 actions.

Drop support for composer cache, we almost never build this anyway so I do not want to spend time maintaining a caching strategy that is never used anyway.